### PR TITLE
Adjust annotation and xaxis for literature chart on coverage page

### DIFF
--- a/js/coverage.js
+++ b/js/coverage.js
@@ -351,6 +351,7 @@ function updateLiteratureChart() {
         let litKanji = litRawData.slice(startIndex, endIndex).reduce((p, c) => [p[0] + c[0], undefined])[0];
         let tempData = [];
         for (let j = 1; j <= 60; j++) tempData.push([j, commonCharCount(kanjiLevelData[j], litKanji)]);
+        tempData.push([61, litKanji.length]);
         litSeriesData.push({
             name: endIndex >= litRawData.length ? ">" + startIndex : (startIndex + 1) + "-" + endIndex,
             data: tempData

--- a/js/coverage.js
+++ b/js/coverage.js
@@ -351,7 +351,6 @@ function updateLiteratureChart() {
         let litKanji = litRawData.slice(startIndex, endIndex).reduce((p, c) => [p[0] + c[0], undefined])[0];
         let tempData = [];
         for (let j = 1; j <= 60; j++) tempData.push([j, commonCharCount(kanjiLevelData[j], litKanji)]);
-        tempData.push([61, litKanji.length]);
         litSeriesData.push({
             name: endIndex >= litRawData.length ? ">" + startIndex : (startIndex + 1) + "-" + endIndex,
             data: tempData

--- a/js/coverage.js
+++ b/js/coverage.js
@@ -241,7 +241,7 @@ async function kanjiListCharts() {
             inverseOrder: true,
             x: {
                 formatter: function (value, data, w) {
-                    if (w == undefined) { let seriesLength = data.series.length == 1 ? data.series[0].slice(-1)[0] : data.series.reduce((p, c) => [p.slice(-1)[0] + c.slice(-1)[0]])[0], currentLength = data.series.length == 1 ? data.series[0][data.dataPointIndex] : data.series.reduce((p, c, i) => [(i == 1 ? p[data.dataPointIndex] : p[0]) + c[data.dataPointIndex]])[0]; return (value != 61 ? "Level " + value : "Completion") + (data.w.config.chart.type == "area" ? " - " + currentLength + "/" + seriesLength + " (" + (currentLength / seriesLength * 100).toFixed(2) + "%)" : ""); }
+                    if (w == undefined) { let seriesLength = data.series.length == 1 ? data.series[0].slice(-1)[0] : data.series.reduce((p, c) => [p.slice(-1)[0] + c.slice(-1)[0]])[0], currentLength = data.series.length == 1 ? data.series[0][data.dataPointIndex] : data.series.reduce((p, c, i) => [(i == 1 ? p[data.dataPointIndex] : p[0]) + c[data.dataPointIndex]])[0]; return (value < 60 ? "Level " + value : "Completion") + (data.w.config.chart.type == "area" ? " - " + currentLength + "/" + seriesLength + " (" + (currentLength / seriesLength * 100).toFixed(2) + "%)" : ""); }
                 }
             },
             y: {


### PR DESCRIPTION
This PR fixes the double "1"s on the xaxis for the literature chart and the tooltip shown for the annotation when level 60 is hovered.

Original:
<img width="1486" alt="Pasted_Image_7_30_22__11_55_PM" src="https://user-images.githubusercontent.com/231727/182010837-a3b29d24-d3aa-4f2b-be55-9c570309d5e1.png">

Proposed:
<img width="1479" alt="Pasted_Image_7_30_22__11_59_PM" src="https://user-images.githubusercontent.com/231727/182010877-eafd41bc-7883-4496-93b8-b827db450efd.png">
.