### PR TITLE
Fix longestStreak calculation

### DIFF
--- a/js/mainWkof.js
+++ b/js/mainWkof.js
@@ -1384,7 +1384,7 @@ async function overviewInfo() {
             streak = 0;
         }
     }
-    longestStreak = Math.max(longestStreak, streak);
+    longestStreak = Math.max(longestStreak, streakCounter);
     document.getElementById("streakOv").innerHTML = streak + " days";
     document.getElementById("streakOv").style.color = streak == longestStreak ? "#55af55" : "#af5555";
     document.getElementById("longestStreakOv").innerHTML = "Longest: " + longestStreak + " days";


### PR DESCRIPTION
If longest streak is the first streak and review array counter `i` goes to `0`), the variable `streak` never gets updated. Use `streakCounter` instead to test if current streak is `longestStreak`.

In my case, I have two streaks. The first one is ~225 days long, then one day without reviews, then a 7 day streak.  The Stats page was incorrectly showing my longest streak as 7.